### PR TITLE
GH-3 create resource skeletons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+.DS_Store
+.build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,5 @@ There are a few base tools that this project relies on the developer to have ins
 2. Docker: https://docs.docker.com/get-docker/.
 3. Task: https://taskfile.dev/installation/.
 
+To initialize and deploy the project, you must have the AWS CLI installed and configured with access.
+

--- a/Delivery.yml
+++ b/Delivery.yml
@@ -1,0 +1,9 @@
+---
+
+Resources:
+
+  CustomResourcePackageBucketV1:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: !Sub "reiddhughes-custom-resource-packages-v1-${AWS::Region}"

--- a/Infrastructure.yml
+++ b/Infrastructure.yml
@@ -1,0 +1,39 @@
+---
+
+Parameters:
+
+  SchemaHandlerPackage:
+    Type: String
+
+Resources:
+
+  AccountResourceExecutionRoleV1:
+    Type: AWS::IAM::Role
+    Properties: 
+      AssumeRolePolicyDocument: 
+        {
+          "Version": "2012-10-17",
+          "Statement": [ 
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ec2.amazonaws.com"
+                ]
+              },
+              "Action": ["sts:AssumeRole"]
+            } 
+          ]  
+        }  
+      Description: Role for running Account custom resources.
+      ManagedPolicyArns: 
+        - arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess
+        - arn:aws:iam::aws:policy/AWSOrganizationsFullAccess
+      RoleName: !Sub "AccountResourceExecutionV1-${AWS::Region}"
+
+  AccountResource:
+    Type: AWS::CloudFormation::ResourceVersion
+    Properties: 
+      ExecutionRoleArn: !GetAtt AccountResourceExecutionRoleV1.Arn
+      SchemaHandlerPackage: !Ref SchemaHandlerPackage
+      TypeName: REIDDHUGHES::Demo::Account

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -12,4 +12,18 @@ tasks:
   install:
     cmds:
       - bash -c '{{ .NODE_ENV }} nvm install v19.8.1'
-    silent: true
+
+  init:
+    cmds:
+      - aws cloudformation deploy --template-file Delivery.yml --stack-name CustomResourcesDelivery --no-fail-on-empty-changeset
+  
+  build:
+    cmds:
+      - mkdir -p .build
+      - zip -j .build/account.zip account/index.js
+      - zip -j .build/account-package.zip .build/account.zip account/schema.json account/.rpdk-config
+
+
+  deploy:
+    cmds:
+      - ./deploy.sh

--- a/account/.rpdk-config
+++ b/account/.rpdk-config
@@ -1,0 +1,22 @@
+{
+    "artifact_type": "RESOURCE",
+    "typeName": "REIDDHUGHES::Demo::Account",
+    "language": "nodejs18.x",
+    "runtime": "nodejs18.x",
+    "entrypoint": "index.handlers.resource",
+    "testEntrypoint": "index.handlers.test_entrypoint",
+    "settings": {
+        "version": false,
+        "subparser_name": null,
+        "verbose": 0,
+        "force": false,
+        "type_name": null,
+        "artifact_type": null,
+        "endpoint_url": null,
+        "region": null,
+        "target_schemas": [],
+        "use_docker": true,
+        "no_docker": false,
+        "protocolVersion": "2.0.0"
+    }
+}

--- a/account/index.js
+++ b/account/index.js
@@ -1,0 +1,26 @@
+const AWSXRay = require('aws-xray-sdk-core')
+const AWS = AWSXRay.captureAWS(require('aws-sdk'))
+
+// Create client outside of handler to reuse
+const lambda = new AWS.Lambda()
+
+// Handler
+exports.handler = async function(event, context) {
+  event.Records.forEach(record => {
+    console.log(record.body)
+  })
+  console.log('## ENVIRONMENT VARIABLES: ' + serialize(process.env))
+  console.log('## CONTEXT: ' + serialize(context))
+  console.log('## EVENT: ' + serialize(event))
+  
+  return getAccountSettings()
+}
+
+// Use SDK client
+var getAccountSettings = function(){
+  return lambda.getAccountSettings().promise()
+}
+
+var serialize = function(object) {
+  return JSON.stringify(object, null, 2)
+}

--- a/account/schema.json
+++ b/account/schema.json
@@ -1,0 +1,86 @@
+{
+    "typeName": "REIDDHUGHES::Demo::Account",
+    "description": "An AWS Account.",
+    "sourceUrl": "https://github.com/reiddhughes/demo-cloud-resource",
+    "documentationUrl": "https://github.com/reiddhughes/demo-cloud-resource",
+    "replacementStrategy": "create_then_delete",
+    "taggable": false,
+    "properties": {
+         "AccountName": {
+            "description": "The name of the Account",
+            "type": "string",
+            "pattern": "[a-z]+"
+        },
+        "AccountId": {
+            "description": "The identifier of the Account",
+            "type": "string",
+            "pattern": "[0-9]{12}"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "AccountName"
+    ],
+    "handlers": {
+        "create": {
+            "permissions": [
+                "dynamodb:GetItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "organizations:CreateAccount",
+                "organizations:DescribeAccount",
+                "organizations:ListAccounts",
+                "organizations:ListCreateAccountStatus"
+            ],
+            "timeoutInMinutes": 30
+        },
+        "read": {
+            "permissions": [
+                "dynamodb:GetItem",
+                "organizations:DescribeAccount",
+                "organizations:ListAccounts",
+                "organizations:ListCreateAccountStatus"
+            ],
+            "timeoutInMinutes": 5
+        },
+        "delete": {
+            "permissions": [
+                "dynamodb:GetItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "organizations:DescribeAccount",
+                "organizations:ListAccounts"
+            ],
+            "timeoutInMinutes": 5
+        },
+        "list": {
+            "permissions": [
+                "dynamodb:GetItem",
+                "organizations:DescribeAccount",
+                "organizations:ListAccounts",
+                "organizations:ListCreateAccountStatus"
+            ],
+            "timeoutInMinutes": 5
+        }
+    },
+    "readOnlyProperties": [
+        "/properties/AccountId"
+    ],
+    "createOnlyProperties": [
+        "/properties/AccountName"
+    ],
+    "primaryIdentifier": [
+        "/properties/AccountName"
+    ],
+    "additionalIdentifiers": [
+        [
+            "/properties/AccountId"
+        ]
+    ],
+    "resourceLink": {
+      "templateUri": "https://us-east-1.console.aws.amazon.com/organizations/v2/home/accounts/${AccountId}",
+      "mappings": {
+        "AccountId": "/AccountId"
+      }
+    }
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+aws s3 cp .build/account-package.zip s3://reiddhughes-custom-resource-packages-v1-us-east-1/account-package.zip
+REGISTRATION_TOKEN=$(aws cloudformation register-type --type RESOURCE --type-name 'REIDDHUGHES::Demo::Account' --schema-handler-package s3://reiddhughes-custom-resource-packages-v1-us-east-1/account-package.zip --query 'RegistrationToken' --output text)
+echo "Registration token is: $REGISTRATION_TOKEN"
+
+echo "Waiting for registration to complete."
+aws cloudformation wait type-registration-complete --registration-token $REGISTRATION_TOKEN
+echo "Registration is complete."

--- a/lifecycle-controller/index.js
+++ b/lifecycle-controller/index.js
@@ -1,0 +1,26 @@
+const AWSXRay = require('aws-xray-sdk-core')
+const AWS = AWSXRay.captureAWS(require('aws-sdk'))
+
+// Create client outside of handler to reuse
+const lambda = new AWS.Lambda()
+
+// Handler
+exports.handler = async function(event, context) {
+  event.Records.forEach(record => {
+    console.log(record.body)
+  })
+  console.log('## ENVIRONMENT VARIABLES: ' + serialize(process.env))
+  console.log('## CONTEXT: ' + serialize(context))
+  console.log('## EVENT: ' + serialize(event))
+  
+  return getAccountSettings()
+}
+
+// Use SDK client
+var getAccountSettings = function(){
+  return lambda.getAccountSettings().promise()
+}
+
+var serialize = function(object) {
+  return JSON.stringify(object, null, 2)
+}


### PR DESCRIPTION
Closes #3

Add resource skeleton for both resources.  Skeleton includes schema, js source files, and rpdk config.  The schema outlines what the resource looks like in cloudformation.  The js files become a lambda that executes on the resource events.  The rpdk config tells cloudformation about how to create the lambda.

Add delivery and infra cloudformation templates.  The delivery file adds resources needed for the deployment and delivery of the project.  The infra template contains the resources for the deployed resource.

Add deploy script and build commands.  Still need to modify this script to deploy the infra yml file instead of doing it directly.